### PR TITLE
issue fixes and README update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -99,6 +99,7 @@ FROM ${BASE_IMAGE}
 RUN set -xe; \
     groupadd -g 1000 darling; \
     useradd -g darling -u 1000 -s /bin/sh -d /home/darling darling; \
+    chown -R 1000:1000 /home/darling; \
     # Install deps. \
     dpkg --add-architecture i386; \
     apt-get update; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -109,6 +109,7 @@ RUN set -xe; \
         flex \
         kmod \
         make \
+        libelf-dev \
         sudo; \
     rm -rf /var/lib/apt/lists/*; \
     # Setup sudo access \

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ kernel module against the running system on container startup. We run the contai
 
 We use a volume mount of your host systems kernel sources (read only) so the kernel module can be built on container startup, this is just an attempt to keep the image somewhat portable.
 
-For Arch Linux Hosts run:  
+For Manjaro/Arch Linux Hosts run:  
 
 ```shell
 docker run -i -t \

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![CircleCI](https://circleci.com/gh/utensils/docker-darling.svg?style=svg)](https://circleci.com/gh/utensils/docker-darling) [![Docker Pulls](https://img.shields.io/docker/pulls/utensils/darling.svg)](https://hub.docker.com/r/utensils/darling/) [![Docker Stars](https://img.shields.io/docker/stars/utensils/darling.svg)](https://hub.docker.com/r/utensils/darling/) [![](https://images.microbadger.com/badges/image/utensils/darling.svg)](https://microbadger.com/images/utensils/darling "Get your own image badge on microbadger.com") [![](https://images.microbadger.com/badges/version/utensils/darling.svg)](https://microbadger.com/images/utensils/darling "Get your own version badge on microbadger.com")  
 
+![Darling Logo](https://upload.wikimedia.org/wikipedia/commons/thumb/a/ae/Darling_project_logo.png/150px-Darling_project_logo.png)
+
 ## About
 
 This is a containerized version of Darling (macOS translation layer). This is an experimental project with the goal to eventually cross compile both iOS and macOS projects in a docker container. I have had some limited success with macOS application builds.
@@ -44,11 +46,21 @@ docker run -i -t \
     --privileged utensils/darling darling shell
 ```
 
-For Ubuntu/Debian Hosts run:  
+For Ubuntu/Debian Linux Hosts run:
 
 ```shell
 docker run -i -t \
     -v /usr/src:/usr/src:ro \
+    --privileged utensils/darling darling shell
+```
+
+For CentOS/RHEL Linux Hosts run:
+
+```shell
+docker run -i -t \
+    -v /lib/modules/"$(uname -r)"/build:/lib/modules/"$(uname -r)"/build:ro \
+    -v /lib/modules/"$(uname -r)"/modules.builtin:/lib/modules/"$(uname -r)"/modules.builtin:ro \
+    -v /lib/modules/"$(uname -r)"/modules.order:/lib/modules/"$(uname -r)"/modules.order:ro \
     --privileged utensils/darling darling shell
 ```
 


### PR DESCRIPTION
commits:

- [fix permission issue: can not generate /home/darling/.darling](https://github.com/motherboard1999/docker-darling/commit/2a7546dcac1934d8ce306204b8e4553d06ead46a)
I have this issue at the first call of "darling shell" inside the Docker container
- [fix Makefile error: Cannot generate ORC matedata for CONFIG_UNWINDER_…](https://github.com/motherboard1999/docker-darling/commit/763330efea99f59bbb793f70590307934d371cda) 
Here I have the issue at the first time, I executed utensils/darling:latest
- [add CentOS/RHEL command and darling logo](https://github.com/motherboard1999/docker-darling/commit/59cad5604690b22c96f8ce23caab882595daf00a)
And I run it under CentOS 8, so here you can find the command